### PR TITLE
Align equation

### DIFF
--- a/ch-metric.tex
+++ b/ch-metric.tex
@@ -2914,33 +2914,14 @@ whenever $z \in [c,d]$ and
 $\abs{z-y} < \delta$, we have
 $\abs{f(x,z)-f(x,y)} < \frac{\epsilon}{b-a}$ for all $x \in [a,b]$.
 So suppose $\abs{z-y} < \delta$.  Then
-\begin{multline*}
-\abs{
-g(z)-
-g(y)
-}
-=
-\abs{
-\int_a^b 
-f(x,z) \,dx 
--
-\int_a^b 
-f(x,y) \,dx 
-}
-\\
-=
-\abs{
-\int_a^b 
-\bigl(
-f(x,z) - f(x,y)
-\bigr)
-\,dx 
-}
-\leq
-(b-a)
-\frac{\epsilon}{b-a}
-= \epsilon . \qedhere
-\end{multline*}
+\begin{equation*}
+\begin{split}
+\abs{g(z)-g(y)}
+& = \abs{\int_a^b f(x,z) \, dx - \int_a^b f(x,y) \, dx }\\
+& = \abs{\int_a^b \bigl(f(x,z) - f(x,y)\bigr) \, dx }\\
+& \leq (b-a) \frac{\epsilon}{b-a} = \epsilon . \qedhere
+\end{split}
+\end{equation*}
 \end{proof}
 
 In applications, if we are interested in continuity at $y_0$, we just


### PR DESCRIPTION
I am not sure whether the "Before pull request" version is intentional but

- This pull request aligns the proof equation of **Proposition 7.5.12** on page 292.

- I tested the re-compiled version; it works fine and these changes do not affect the page number of the book.

Thank you!

![proposition_7 5 12_proof](https://github.com/jirilebl/ra/assets/40212849/ffa50a62-b508-4b5c-921f-9b919ae4b571)
