### PR TITLE
Update Book of Proof citations to link to current website.

### DIFF
--- a/realanal.tex
+++ b/realanal.tex
@@ -577,7 +577,7 @@ at github: \url{https://github.com/jirilebl/ra}
 \bib{Hammack}{misc}{
    author={Hammack, Richard},
    title={Book of Proof},
-   note={Available at \url{http://www.people.vcu.edu/~rhammack/BookOfProof/}},
+   note={Available at \url{https://richardhammack.github.io/BookOfProof/}},
 }
 
 \bib{Rosenlicht}{book}{

--- a/realanal12.tex
+++ b/realanal12.tex
@@ -685,7 +685,7 @@ at github: \url{https://github.com/jirilebl/ra}
 \bib{Hammack}{misc}{
    author={Hammack, Richard},
    title={Book of Proof},
-   note={Available at \url{http://www.people.vcu.edu/~rhammack/BookOfProof/}},
+   note={Available at \url{https://richardhammack.github.io/BookOfProof/}},
 }
 
 \bib{Rosenlicht}{book}{


### PR DESCRIPTION
Awhile ago, Richard Hammack's Book of Proof webpage moved from vcu.edu to GitHub Pages.

This pull request updates the citation to the current link.

Thank you!